### PR TITLE
use local logging driver for docker

### DIFF
--- a/packages/docker
+++ b/packages/docker
@@ -15,3 +15,10 @@ rm get-docker.sh
 sudo groupadd -f docker
 sudo usermod -aG docker "$USER"
 newgrp docker
+
+# use local logging driver to prevent disk-exhaustion
+# local logging driver performs log-rotation & compresses log files by default.
+# https://docs.docker.com/config/containers/logging/configure/
+sudo touch /etc/docker/daemon.json
+echo '{"log-driver": "local", "log-opts": {"max-size": "10m"}}' \
+    | sudo tee /etc/docker/daemon.json > /dev/null


### PR DESCRIPTION
Since the post-install script is meant for desktop use, the `local` logging driver should be used to prevent disk exhaustion.

![image](https://github.com/user-attachments/assets/1d6e72a9-71d0-4f2e-95b3-38bae943651f)
